### PR TITLE
feat: Dockerfile + .dockerignore API Express

### DIFF
--- a/api/.dockerignore
+++ b/api/.dockerignore
@@ -1,0 +1,6 @@
+node_modules
+npm-debug.log*
+.env
+.git
+.gitignore
+README.md

--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -1,0 +1,23 @@
+# === Dockerfile API TerrangaFood ===
+
+# Étape 1 : Image de base
+FROM node:20-alpine
+
+# Étape 2 : Répertoire de travail
+WORKDIR /app
+
+# Étape 3 : Copier les fichiers de dépendances
+# (pour profiter du cache Docker)
+COPY package.json package-lock.json ./
+
+# Étape 4 : Installer les dépendances
+RUN npm install --production
+
+# Étape 5 : Copier le code source
+COPY . .
+
+# Étape 6 : Exposer le port
+EXPOSE 3001
+
+# Étape 7 : Commande de démarrage
+CMD ["node", "src/app.js"]


### PR DESCRIPTION
Ajout du Dockerfile et du fichier .dockerignore pour l’API.
Permet de construire l’image Docker et de lancer l’application avec Docker.
close #38 