### PR TITLE
doc: URLs de production dans README

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,3 +126,8 @@ et pour l'autre package.json contient trois scrips pour gérer le lancement de m
 --> "dev" : "nodemon src/app.js"
 --> "start" : "node src/app.js"
 --> "seed" : "node -r dotenv/config src/seed/seed.js"
+
+## URLs de production
+
+- Frontend : https://terrangafood-tec-vibes.vercel.app
+- API : https://terrangafood-api-tec-vibes.onrender.com


### PR DESCRIPTION
Ajout des URLs de production dans le README pour la démonstration finale de l’application TerrangaFood.

- Frontend déployé sur Vercel
- API déployée sur Render
- Application accessible en ligne

Closes #52 